### PR TITLE
update for framework admin sql

### DIFF
--- a/development/mysql/dc.yml
+++ b/development/mysql/dc.yml
@@ -46,6 +46,7 @@ spec:
             cat <<\EOF > 1_alter_user.sh
             #! /bin/bash
             MYSQL_PWD=$MYSQL_ROOT_PASSWORD mysql -S /tmp/mysql.sock -u root -e "ALTER USER 'apiuser'@'%' IDENTIFIED BY '$ALTER_USER_PASSWORD'"
+            MYSQL_PWD=$MYSQL_ROOT_PASSWORD mysql -S /tmp/mysql.sock -u root -e "ALTER USER 'frameworkadmin'@'%' IDENTIFIED BY '$ALTER_ADMINUSER_PASSWORD'"
             EOF
       containers:
       - env:
@@ -63,6 +64,11 @@ spec:
           valueFrom:
             secretKeyRef:
               key: alter-user-password
+              name: mysql
+        - name: ALTER_ADMINUSER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: alter-adminuser-password
               name: mysql
         image: percona:8.0-centos
         imagePullPolicy: IfNotPresent

--- a/development/mysql/dc.yml
+++ b/development/mysql/dc.yml
@@ -70,7 +70,7 @@ spec:
             secretKeyRef:
               key: alter-adminuser-password
               name: mysql
-        image: percona:8.0-centos
+        image: percona:8.0.13-4-centos
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/development/mysql/secret.yml
+++ b/development/mysql/secret.yml
@@ -7,3 +7,4 @@ data:
   database-root-password: {{ mysql_root_password | b64encode }}
   database-name: {{ mysql_database_name | b64encode }}
   alter-user-password: {{ alter_user_password | b64encode }}
+  alter-adminuser-password: {{alter_adminuser_password | b64encode }}

--- a/development/mysql/vars
+++ b/development/mysql/vars
@@ -2,3 +2,4 @@ namespace: development
 mysql_root_password: !ssm /okd/development/mysql/root_password
 mysql_database_name: arbiter_data
 alter_user_password: !ssm /okd/development/sfa-api/mysql_password
+alter_adminuser_password: !ssm /okd/development/sfa-api/adminmysql_password


### PR DESCRIPTION
The deployment component of https://github.com/SolarArbiter/solarforecastarbiter-api/pull/155, I've added the associated secret, and this appears to be templating correctly. For the CLI, the api config with also need to be updated. perhaps that should be added to this request?