### PR TITLE
update dashboard to start app properly with gunicorn 20

### DIFF
--- a/development/sfa-dash/dc.yml
+++ b/development/sfa-dash/dc.yml
@@ -24,7 +24,7 @@ spec:
         - name: prometheus_multiproc_dir
           value: /metrics
         - name: APP_MODULE
-          value: sfa_dash:create_app_with_metrics({% if dash_config is defined %}'{{ dash_config }}'{% endif %})
+          value: {{ dashboard_app }}
         - name: APP_CONFIG
           value: ./gunicorn_config.py
         - name: SENTRY_DSN

--- a/development/sfa-dash/vars
+++ b/development/sfa-dash/vars
@@ -4,4 +4,5 @@ flask_secret_key: !ssm /okd/development/sfa-dash/flask_secret_key
 auth0_client_id: !ssm /okd/development/sfa-dash/auth0_client_id
 auth0_client_secret: !ssm /okd/development/sfa-dash/auth0_client_secret
 sentry_dsn: !ssm /okd/sentry/dashdsn
+dashboard_app: 'sfa_dash:dev_app'
 github_core_trigger_secret: !ssm /okd/development/sfa-core/github_trigger_secret

--- a/production/sfa-dash/vars
+++ b/production/sfa-dash/vars
@@ -5,7 +5,7 @@ auth0_client_secret: !ssm /okd/production/sfa-dash/auth0_client_secret
 dash_prefix: ''
 dash_image_tag: stable
 sentry_dsn: !ssm /okd/sentry/dashdsn
-dash_config: 'sfa_dash.config.ProdConfig'
+dashboard_app: 'sfa_dash:app'
 mysql_secret: true
 mysql_password: !ssm /okd/production/sfa-dash/mysql_password
 mysql_user: !ssm /okd/production/sfa-dash/mysql_user


### PR DESCRIPTION
Moved configuration selection inside the `__getattr__` found in sfa_dash. So now the `dashboard_app` variable is used to select which version of the application to run.